### PR TITLE
requirements: add missing setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv==1.0.0
 hexbytes==0.3.1
 aiohttp==3.10.11
 requests==2.32.3
+setuptools==79.0.1


### PR DESCRIPTION
The Python SDK on Linux machine fails to run because of absence of module `pkg_resources`, so install it.

Error details:
```
(myenv) [triste@reeva ethena-minting-client]$ python3 ./py/mint_script.py
Traceback (most recent call last):
  File "/home/triste/blockchain/ethena-on-base/ethena-minting-client/./py/mint_script.py", line 11, in <module>
    from web3 import Web3
  File "/home/triste/blockchain/ethena-on-base/ethena-minting-client/myenv/lib/python3.13/site-packages/web3/__init__.py", line 2, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```