### PR TITLE
chore(deps): add minimum-release-age to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Refuse to install package versions younger than 10 days (supply-chain defense)
+# Requires pnpm >= 10.16
+minimum-release-age=14400


### PR DESCRIPTION
## What
Add `.npmrc` with `minimum-release-age=14400` (10 days) so pnpm refuses to install package versions younger than 10 days.

## Why
Defense against npm supply-chain attacks. A 10-day install-time quarantine gives the ecosystem time to detect and unpublish malicious releases before they reach our builds.

This complements the existing `minimumReleaseAge: "15 days"` in [ethena-labs/renovate-config](https://github.com/ethena-labs/renovate-config) (PR-creation fence) with an install-time fence — protecting against any path that bypasses Renovate (manual edits, transitive deps, etc.).

`minimum-release-age` was introduced in pnpm 10.16. This repo does not pin `packageManager`, so confirm the local/CI pnpm version is ≥ 10.16 for the setting to take effect (the setting is silently ignored on older versions).

## Test plan
- [ ] `pnpm install` succeeds on this branch with no lockfile churn
- [ ] CI green

## Security & Data Impact
**Security impact:** Reduces exposure window for compromised npm packages by deferring installation of versions less than 10 days old.
**Data classification affected:** None.
**Audit log updated:** N/A.

## Rollback
Delete `.npmrc` — no state migration.
