### PR TITLE
fix(deps): override ws, form-data, and hono to patched versions (CVE-2026-48779, CVE-2026-12143, CVE-2026-54290)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,8 @@ overrides:
   postcss@<8.5.10: 8.5.10
   hono@<4.12.18: 4.12.18
   fast-uri@<=3.1.1: 3.1.2
+  ws@>=8.0.0 <8.21.0: '>=8.21.0'
+  form-data@>=4.0.0 <4.0.6: '>=4.0.6'
 
 importers:
 
@@ -697,7 +699,7 @@ packages:
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
       '@types/react': '*'
-      react: '>=19.0.1'
+      react: '>=19.1.2'
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2558,8 +2560,8 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fraction.js@4.3.7:
@@ -2655,6 +2657,10 @@ packages:
 
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hono@4.12.18:
@@ -2837,12 +2843,12 @@ packages:
   isows@1.0.6:
     resolution: {integrity: sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==}
     peerDependencies:
-      ws: '*'
+      ws: '>=8.21.0'
 
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
-      ws: '*'
+      ws: '>=8.21.0'
 
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
@@ -3445,7 +3451,7 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': '*'
-      react: '>=19.0.1'
+      react: '>=19.1.2'
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -4079,30 +4085,6 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -6957,7 +6939,7 @@ snapshots:
   axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -7278,7 +7260,7 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3
       engine.io-parser: 5.2.3
-      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       xmlhttprequest-ssl: 2.1.2
     transitivePeerDependencies:
       - bufferutil
@@ -7709,12 +7691,12 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   fraction.js@4.3.7: {}
@@ -7817,6 +7799,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -7986,13 +7972,13 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isows@1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
+  isows@1.0.6(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
     dependencies:
-      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
-  isows@1.0.7(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
+  isows@1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
     dependencies:
-      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   iterator.prototype@1.1.5:
     dependencies:
@@ -9290,9 +9276,9 @@ snapshots:
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
       abitype: 1.0.8(typescript@5.7.3)(zod@3.25.76)
-      isows: 1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      isows: 1.0.6(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ox: 0.6.7(typescript@5.7.3)(zod@3.25.76)
-      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -9307,9 +9293,9 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.7.3)(zod@3.22.4)
-      isows: 1.0.7(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ox: 0.14.22(typescript@5.7.3)(zod@3.22.4)
-      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -9324,9 +9310,9 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.7.3)(zod@3.25.76)
-      isows: 1.0.7(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ox: 0.14.22(typescript@5.7.3)(zod@3.25.76)
-      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -9341,9 +9327,9 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.7.3)(zod@4.4.3)
-      isows: 1.0.7(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ox: 0.14.22(typescript@5.7.3)(zod@4.4.3)
-      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -9463,16 +9449,6 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@5.0.10):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 5.0.10
-
-  ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 5.0.10
-
-  ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 5.0.10

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ overrides:
   bn.js@<4.12.3: '>=4.12.3'
   axios@>=1.0.0 <1.15.2: 1.16.0
   postcss@<8.5.10: 8.5.10
-  hono@<4.12.18: 4.12.18
+  hono@<4.12.25: '>=4.12.25'
   fast-uri@<=3.1.1: 3.1.2
   ws@>=8.0.0 <8.21.0: '>=8.21.0'
   form-data@>=4.0.0 <4.0.6: '>=4.0.6'
@@ -2663,8 +2663,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
 
   idb-keyval@6.2.1:
@@ -7806,7 +7806,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.18: {}
+  hono@4.12.27: {}
 
   idb-keyval@6.2.1: {}
 
@@ -8480,7 +8480,7 @@ snapshots:
   porto@0.2.35(@tanstack/react-query@5.100.13(react@19.2.4))(@types/react@19.0.6)(@wagmi/core@2.22.1(@tanstack/query-core@5.100.13)(@types/react@19.0.6)(react@19.2.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.50.4(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.50.4(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.100.13)(@tanstack/react-query@5.100.13(react@19.2.4))(@types/react@19.0.6)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.50.4(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)):
     dependencies:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.100.13)(@types/react@19.0.6)(react@19.2.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.50.4(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.25.76))
-      hono: 4.12.18
+      hono: 4.12.27
       idb-keyval: 6.2.4
       mipd: 0.0.7(typescript@5.7.3)
       ox: 0.9.17(typescript@5.7.3)(zod@4.4.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,10 +45,10 @@ overrides:
   bn.js@<4.12.3: '>=4.12.3'
   axios@>=1.0.0 <1.15.2: 1.16.0
   postcss@<8.5.10: 8.5.10
-  hono@<4.12.25: '>=4.12.25'
+  hono@<4.12.25: '>=4.12.25 <5.0.0'
   fast-uri@<=3.1.1: 3.1.2
-  ws@>=8.0.0 <8.21.0: '>=8.21.0'
-  form-data@>=4.0.0 <4.0.6: '>=4.0.6'
+  ws@>=8.0.0 <8.21.0: '>=8.21.0 <9.0.0'
+  form-data@>=4.0.0 <4.0.6: '>=4.0.6 <5.0.0'
 
 importers:
 
@@ -2843,12 +2843,12 @@ packages:
   isows@1.0.6:
     resolution: {integrity: sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==}
     peerDependencies:
-      ws: '>=8.21.0'
+      ws: '>=8.21.0 <9.0.0'
 
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
-      ws: '>=8.21.0'
+      ws: '>=8.21.0 <9.0.0'
 
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -87,6 +87,11 @@ overrides:
   "postcss@<8.5.10": "8.5.10"
   "hono@<4.12.18": "4.12.18"
   "fast-uri@<=3.1.1": "3.1.2"
+  # CVE-2026-48779: ws DoS via oversized headers. Only the 8.x line is
+  # affected (8.18.0/8.20.1 in-tree); ws@7.5.11 is already patched, leave it.
+  "ws@>=8.0.0 <8.21.0": ">=8.21.0"
+  # CVE-2026-12143: form-data predictable multipart boundary
+  "form-data@>=4.0.0 <4.0.6": ">=4.0.6"
 
 # Dependencies permitted to run install/build scripts (all known native tools).
 allowBuilds:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -85,7 +85,7 @@ overrides:
   "bn.js@<4.12.3": ">=4.12.3"
   "axios@>=1.0.0 <1.15.2": "1.16.0"
   "postcss@<8.5.10": "8.5.10"
-  "hono@<4.12.18": "4.12.18"
+  "hono@<4.12.25": ">=4.12.25"  # CVE-2026-54290 (was <4.12.18 -> 4.12.18, now itself vulnerable)
   "fast-uri@<=3.1.1": "3.1.2"
   # CVE-2026-48779: ws DoS via oversized headers. Only the 8.x line is
   # affected (8.18.0/8.20.1 in-tree); ws@7.5.11 is already patched, leave it.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -85,13 +85,13 @@ overrides:
   "bn.js@<4.12.3": ">=4.12.3"
   "axios@>=1.0.0 <1.15.2": "1.16.0"
   "postcss@<8.5.10": "8.5.10"
-  "hono@<4.12.25": ">=4.12.25"  # CVE-2026-54290 (was <4.12.18 -> 4.12.18, now itself vulnerable)
+  "hono@<4.12.25": ">=4.12.25 <5.0.0"  # CVE-2026-54290 (was <4.12.18 -> 4.12.18, now itself vulnerable)
   "fast-uri@<=3.1.1": "3.1.2"
   # CVE-2026-48779: ws DoS via oversized headers. Only the 8.x line is
   # affected (8.18.0/8.20.1 in-tree); ws@7.5.11 is already patched, leave it.
-  "ws@>=8.0.0 <8.21.0": ">=8.21.0"
+  "ws@>=8.0.0 <8.21.0": ">=8.21.0 <9.0.0"
   # CVE-2026-12143: form-data predictable multipart boundary
-  "form-data@>=4.0.0 <4.0.6": ">=4.0.6"
+  "form-data@>=4.0.0 <4.0.6": ">=4.0.6 <5.0.0"
 
 # Dependencies permitted to run install/build scripts (all known native tools).
 allowBuilds:


### PR DESCRIPTION
## What
Add/refresh `pnpm-workspace.yaml` overrides to clear three Dependabot advisories in `ethena-minting-client`: `ws`, `form-data`, and `hono`. All override targets are capped within their current major.

## Why
All three were resolvable at vulnerable versions:
- **`ws` CVE-2026-48779** (`>=8.0.0 <8.21.0`, DoS via oversized headers) — in-tree at 8.18.0 and 8.20.1
- **`form-data` CVE-2026-12143** (`>=4.0.0 <4.0.6`, CRLF injection via unescaped multipart) — in-tree at 4.0.5
- **`hono` CVE-2026-54290** (`<4.12.25`, CORS middleware reflects any Origin with credentials) — pinned at **4.12.18** by a now-stale override (`"hono@<4.12.18": "4.12.18"`), and 4.12.18 is itself vulnerable

## Changes
`pnpm-workspace.yaml` overrides (matching the existing range-selector style, each capped to the next major so a future re-lock can't float to a breaking version):
- `"ws@>=8.0.0 <8.21.0": ">=8.21.0 <9.0.0"` — bumps only the vulnerable 8.x line. `ws@7.5.11` is a separate, already-patched major line and is left untouched.
- `"form-data@>=4.0.0 <4.0.6": ">=4.0.6 <5.0.0"`
- `"hono@<4.12.18": "4.12.18"` → `"hono@<4.12.25": ">=4.12.25 <5.0.0"` — updates the **existing stale override**. Widened the key to `<4.12.25` (a strict superset of `<4.12.18`, so the same transitive consumers still match) and raised/capped the target.

## Test plan
- `pnpm install --lockfile-only` regenerated the lockfile; it passes the repo supply-chain policies (`minimumReleaseAge`, `trustPolicy: no-downgrade`, `blockExoticSubdeps`).
- Post-change resolved versions: `ws` → **7.5.11** + **8.21.0**, `form-data` → **4.0.6**, `hono` → **4.12.27**. Zero vulnerable versions remain.
- The capped override specs are mirrored into the lockfile `overrides:` block.

## Lockfile diff scope (full accounting)
Version-key changes are limited to the three targets plus their direct dependents:
- `ws` 8.18.0/8.20.1 removed (8.21.0 retained), `form-data` 4.0.5 → 4.0.6, `hono` 4.12.18 → 4.12.27
- `isows` peer edges re-point to `ws@8.21.0`
- Two incidental, benign regeneration effects (not introduced by these overrides):
  - `hasown` 2.0.3 → 2.0.4 (patch)
  - two recorded `react` peerDependency floors tighten `>=19.0.1` → `>=19.1.2` on `@radix-ui/react-compose-refs` and `react-remove-scroll`. This is pnpm re-materializing the **pre-existing** `react@>=19.1.0 <19.1.2` override into the peer-requirement metadata during regeneration — no react version actually changes in the resolved graph.

## Security & Data Impact
**Security impact:** Removes three transitively-reachable advisories. `ws` (WebSocket client, wallet/RPC providers), `form-data` (multipart HTTP bodies), and `hono` (HTTP router/framework). No application code changed.
**Data classification affected:** None
**Audit log updated:** n/a

## Rollback
No state migration -- revert commit is sufficient.