### PR TITLE
fix(deps): remediate axios GHSA-gcfj and idna CVE-2026-45409

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -279,20 +279,24 @@ This ensures the patched version is used even if upstream packages haven't yet b
 
 ---
 
-## Axios CRLF Header Injection / IMDSv2 Bypass & NO_PROXY SSRF (#126, #128)
+## Axios advisories (#126, #128, GHSA-gcfj-64vw-6mp9)
 
 ### Overview
-Two related vulnerabilities in Axios (npm) affecting all `>= 1.0.0, < 1.15.0`.
+Multiple axios (npm) advisories remediations are stacked behind one override to `1.18.0`:
+- **#126 / #128** — CRLF header injection chain (IMDSv2 bypass) and `NO_PROXY` hostname normalisation bypass (SSRF); originally affected `>= 1.0.0, < 1.15.0` (patched floor was `1.15.0`).
+- **GHSA-gcfj-64vw-6mp9** — Node HTTP adapter can inherit a polluted `Object.prototype.proxy` after interceptor config cloning; affected `>= 1.15.2, < 1.18.0` (patched floor `1.18.0`).
 
 ### Vulnerability Details
-- **CVE / Issues**: #126 (CRLF header injection chain → IMDSv2 bypass, CVSS 9.9), #128 (NO_PROXY hostname normalisation bypass → SSRF)
-- **Affected versions**: `>= 1.0.0, < 1.15.0`
-- **Patched version**: `1.15.0`
-- **Severity**: Critical (#126), High (#128)
+- **CVE / Issues**: #126 (CRLF header injection chain → IMDSv2 bypass, CVSS 9.9), #128 (NO_PROXY hostname normalisation bypass → SSRF), GHSA-gcfj-64vw-6mp9 (inherited proxy after interceptor cloning)
+- **Affected versions (union currently mitigated)**: `>= 1.0.0, < 1.18.0` (plus the 0.x band handled separately below)
+- **Current patched floor**: `1.18.0`
+- **Severity**: Critical (#126), High (#128 / GHSA-gcfj-64vw-6mp9)
 
 **#126 — CRLF Header Injection:** If any dependency in the stack has a prototype-pollution vulnerability, polluted `Object.prototype` properties are merged into Axios request headers without CRLF sanitisation. A crafted `\r\n` sequence in a header value becomes a request-smuggling payload, enabling AWS IMDSv2 bypass and IAM credential theft.
 
 **#128 — NO_PROXY Bypass:** Axios performs literal string comparison for `NO_PROXY` rules. Hostnames with a trailing dot (`localhost.`) or IPv6 literals (`[::1]`) bypass the check and are incorrectly proxied through any configured HTTP proxy, undermining SSRF protections.
+
+**GHSA-gcfj-64vw-6mp9 — Inherited proxy after interceptor cloning:** Axios hardens merged request config with a null-prototype object, but a common interceptor pattern (`{...config}` / `Object.assign({}, config)`) re-materialises a regular object. The Node HTTP adapter then reads `config.proxy` through the prototype chain, so a polluted `Object.prototype.proxy` can redirect plaintext HTTP requests.
 
 ### Remediation
 - **Mitigation date**: 2026-04-16 (updated 2026-08-05 for GHSA-gcfj-64vw-6mp9)
@@ -316,7 +320,7 @@ Two related vulnerabilities in Axios (npm) affecting all `>= 1.0.0, < 1.15.0`.
 - **Affected versions**: `< 3.15`
 - **Patched version**: `>= 3.15`
 - **Severity**: Medium
-- **Was resolved**: `3.14` (still vulnerable for alternate entry points)
+- **Previously locked version**: `3.14` (above the incomplete 3.14 partial fix for `encode()`, but still below the 3.15 floor covering alternate entry points)
 
 ### Remediation
 - **Mitigation date**: 2026-08-05

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -295,14 +295,37 @@ Two related vulnerabilities in Axios (npm) affecting all `>= 1.0.0, < 1.15.0`.
 **#128 — NO_PROXY Bypass:** Axios performs literal string comparison for `NO_PROXY` rules. Hostnames with a trailing dot (`localhost.`) or IPv6 literals (`[::1]`) bypass the check and are incorrectly proxied through any configured HTTP proxy, undermining SSRF protections.
 
 ### Remediation
-- **Mitigation date**: 2026-04-16
+- **Mitigation date**: 2026-04-16 (updated 2026-08-05 for GHSA-gcfj-64vw-6mp9)
 - **Mitigation type**: pnpm override (transitive — blocked from direct parent upgrade)
-- **axios**: Overridden to `1.15.0` via pnpm override in `ui/package.json`
+- **axios**: Overridden to `1.18.0` via root `pnpm-workspace.yaml` (`axios@>=1.0.0 <1.18.0`)
+- **Note**: Prior redirect target `1.16.0` (from an earlier advisory) fell inside the new vulnerable range `>=1.15.2 <1.18.0` and was refreshed to `1.18.0`
 - **Transitive paths fixed**: `@rainbow-me/rainbowkit → axios` and `wagmi → axios`
-- **Validation**: pnpm lockfile regenerated; `axios@1.13.6` no longer present
+- **Validation**: pnpm lockfile regenerated; `axios@1.16.0` no longer present
 
 ### Impact Surface
-`axios` is a runtime dependency of `@rainbow-me/rainbowkit` and `wagmi` (wallet connection stack). These libraries run **client-side in the browser** — a backend SSRF or IMDSv2 attack is not directly applicable in this context. The prototype-pollution gadget chain (CWE-113) remains a theoretical risk if any other browser-side dependency introduces prototype pollution, but no such dependency is currently present.
+`axios` is a runtime dependency of `@rainbow-me/rainbowkit` and `wagmi` (wallet connection stack). These libraries run **client-side in the browser**. GHSA-gcfj-64vw-6mp9 specifically affects the Node HTTP adapter after interceptor config cloning; browser adapters are not the primary impact path. Residual risk remains if any server-side Node axios usage inherits a polluted `Object.prototype.proxy`.
+
+---
+
+## CVE-2026-45409 — idna DoS via incomplete length checks
+
+### Overview
+**CVE-2026-45409 / GHSA-65pc-fj4g-8rjx** — specially crafted inputs to `idna.encode()` (and lesser-used alternate helpers) can bypass the CVE-2024-3651 length guard and consume excessive CPU.
+
+### Vulnerability Details
+- **Affected versions**: `< 3.15`
+- **Patched version**: `>= 3.15`
+- **Severity**: Medium
+- **Was resolved**: `3.14` (still vulnerable for alternate entry points)
+
+### Remediation
+- **Mitigation date**: 2026-08-05
+- **Mitigation type**: uv `override-dependencies` (transitive)
+- **idna**: `idna>=3.15` under `[tool.uv] override-dependencies`
+- **Validation**: `uv lock` regenerated; lockfile resolves `idna` to `>=3.15`
+
+### Impact Surface
+Transitive via `requests` / `aiohttp` / `yarl` used by the Python minting client for HTTP calls. Exploitation requires attacker-controlled domain-like strings of extreme length; normal DNS hostnames are capped at 253 characters.
 
 ---
 
@@ -354,7 +377,7 @@ The following overrides are configured in `ui/package.json`:
   "flatted@<3.4.0": ">=3.4.0",
   "ajv@<6.14.0": ">=6.14.0",
   "bn.js@<4.12.3": ">=4.12.3",
-  "axios@>=1.0.0 <1.15.0": "1.15.0"
+  "axios@>=1.0.0 <1.18.0": "1.18.0"
 }
 ```
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   slow-redact: 0.3.1
   diff@<4.0.4: '>=4.0.4'
   diff@>=5.0.0 <8.0.3: '>=8.0.3'
-  axios@1.14.1: 1.16.0
+  axios@>=1.0.0 <1.18.0: 1.18.0
   axios@0.30.4: 0.30.3
   plain-crypto-js@4.2.1: 0.0.0-security
   react@19.0.0: '>=19.0.1'
@@ -43,7 +43,6 @@ overrides:
   flatted@<3.4.0: '>=3.4.0'
   ajv@<6.14.0: '>=6.14.0'
   bn.js@<4.12.3: '>=4.12.3'
-  axios@>=1.0.0 <1.15.2: 1.16.0
   postcss@<8.5.10: 8.5.10
   hono@<4.12.25: '>=4.12.25 <5.0.0'
   fast-uri@<=3.1.1: 3.1.2
@@ -1812,6 +1811,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
@@ -1914,10 +1917,10 @@ packages:
   axios-retry@4.5.0:
     resolution: {integrity: sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==}
     peerDependencies:
-      axios: 1.16.0
+      axios: 1.18.0
 
-  axios@1.16.0:
-    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
+  axios@1.18.0:
+    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -2666,6 +2669,10 @@ packages:
   hono@4.12.27:
     resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   idb-keyval@6.2.1:
     resolution: {integrity: sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==}
@@ -4224,6 +4231,7 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - immer
       - react
+      - supports-color
       - typescript
       - use-sync-external-store
       - utf-8-validate
@@ -4235,8 +4243,8 @@ snapshots:
       '@solana-program/token': 0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@5.0.10))
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@5.0.10)
       abitype: 1.0.6(typescript@5.7.3)(zod@3.25.76)
-      axios: 1.16.0
-      axios-retry: 4.5.0(axios@1.16.0)
+      axios: 1.18.0
+      axios-retry: 4.5.0(axios@1.18.0)
       bs58: 6.0.0
       jose: 6.2.3
       md5: 2.3.0
@@ -4247,6 +4255,7 @@ snapshots:
       - bufferutil
       - debug
       - fastestsmallesttextencoderdecoder
+      - supports-color
       - typescript
       - utf-8-validate
 
@@ -4701,7 +4710,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.13
-      debug: 4.3.4
+      debug: 4.4.3
       pony-cause: 2.1.11
       semver: 7.8.1
       uuid: 9.0.1
@@ -4715,7 +4724,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.13
-      debug: 4.3.4
+      debug: 4.4.3
       pony-cause: 2.1.11
       semver: 7.8.1
       uuid: 9.0.1
@@ -6804,6 +6813,12 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -6931,18 +6946,20 @@ snapshots:
 
   axe-core@4.11.4: {}
 
-  axios-retry@4.5.0(axios@1.16.0):
+  axios-retry@4.5.0(axios@1.18.0):
     dependencies:
-      axios: 1.16.0
+      axios: 1.18.0
       is-retry-allowed: 2.2.0
 
-  axios@1.16.0:
+  axios@1.18.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
@@ -7807,6 +7824,13 @@ snapshots:
       function-bind: 1.1.2
 
   hono@4.12.27: {}
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   idb-keyval@6.2.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,8 +50,8 @@ overrides:
   "diff@<4.0.4": ">=4.0.4"
   "diff@>=5.0.0 <8.0.3": ">=8.0.3"
   # GHSA-gcfj-64vw-6mp9: prior redirect target 1.16.0 is itself vulnerable
-  # (>=1.15.2 <1.18.0). Keep 0.x pin within its major (0.30.3 is outside
-  # the 0.31.1–0.33.0 affected band for this advisory).
+  # (>=1.15.2 <1.18.0). Keep the 0.30.x pin within that minor line (0.30.3
+  # is outside the 0.31.1–0.33.0 affected band for this advisory).
   "axios@>=1.0.0 <1.18.0": "1.18.0"
   "axios@0.30.4": "0.30.3"
   "plain-crypto-js@4.2.1": "0.0.0-security"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,7 +49,10 @@ overrides:
   # From root package.json
   "diff@<4.0.4": ">=4.0.4"
   "diff@>=5.0.0 <8.0.3": ">=8.0.3"
-  "axios@1.14.1": "1.16.0"
+  # GHSA-gcfj-64vw-6mp9: prior redirect target 1.16.0 is itself vulnerable
+  # (>=1.15.2 <1.18.0). Keep 0.x pin within its major (0.30.3 is outside
+  # the 0.31.1–0.33.0 affected band for this advisory).
+  "axios@>=1.0.0 <1.18.0": "1.18.0"
   "axios@0.30.4": "0.30.3"
   "plain-crypto-js@4.2.1": "0.0.0-security"
   # Migrated from ui/package.json#pnpm.overrides
@@ -83,7 +86,6 @@ overrides:
   "flatted@<3.4.0": ">=3.4.0"
   "ajv@<6.14.0": ">=6.14.0"
   "bn.js@<4.12.3": ">=4.12.3"
-  "axios@>=1.0.0 <1.15.2": "1.16.0"
   "postcss@<8.5.10": "8.5.10"
   "hono@<4.12.25": ">=4.12.25 <5.0.0"  # CVE-2026-54290 (was <4.12.18 -> 4.12.18, now itself vulnerable)
   "fast-uri@<=3.1.1": "3.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev-dependencies = [
 ]
 override-dependencies = [
     "urllib3>=2.7.0",
+    "idna>=3.15",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -7,11 +7,14 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-11T07:25:52.108557Z"
+exclude-newer = "2026-07-26T09:34:42.24811Z"
 exclude-newer-span = "P10D"
 
 [manifest]
-overrides = [{ name = "urllib3", specifier = ">=2.7.0" }]
+overrides = [
+    { name = "idna", specifier = ">=3.15" },
+    { name = "urllib3", specifier = ">=2.7.0" },
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -728,11 +731,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.14"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/b1/efac073e0c297ecf2fb33c346989a529d4e19164f1759102dee5953ee17e/idna-3.14.tar.gz", hash = "sha256:466d810d7a2cc1022bea9b037c39728d51ae7dad40d480fc9b7d7ecf98ba8ee3", size = 198272, upload-time = "2026-05-10T20:32:15.935Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/3c/3f62dee257eb3d6b2c1ef2a09d36d9793c7111156a73b5654d2c2305e5ce/idna-3.14-py3-none-any.whl", hash = "sha256:e677eaf072e290f7b725f9acf0b3a2bd55f9fd6f7c70abe5f0e34823d0accf69", size = 72184, upload-time = "2026-05-10T20:32:14.295Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
Refresh the stale axios pnpm override to `1.18.0` and pin transitive `idna` to `>=3.15` via uv `override-dependencies`.

## Why
- **GHSA-gcfj-64vw-6mp9 (HIGH):** prior override redirected consumers to `axios@1.16.0`, which is inside the newly reported vulnerable range `>=1.15.2,<1.18.0`. Patched floor is `1.18.0`.
- **CVE-2026-45409 (MEDIUM):** `idna` `<3.15` is vulnerable; lockfile was on `3.14`. Package is transitive (via `requests`/`aiohttp`/`yarl`) so an uv override is required.

## Test plan
- [x] `pnpm install --lockfile-only` — lock resolves `axios@1.18.0`; no `1.15–1.17`
- [x] `uv lock` — `idna` `3.14` → `3.18`
- [x] CI passes

## Security & Data Impact
**Security impact:** Mitigates GHSA-gcfj-64vw-6mp9 (axios Node HTTP adapter proxy inheritance) and CVE-2026-45409 (idna DoS). Axios is primarily pulled by the wallet UI stack (browser); idna is used on Python HTTP client paths.
**Data classification affected:** none
**Audit log updated:** n/a

## Rollback
No state migration — revert commit is sufficient.