### PR TITLE
fix(deps): widen uuid override to clear CVE-2026-41907

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -416,14 +416,13 @@ The following overrides are configured in root `package.json`:
 - **Mitigation type:** override (fail-closed); prior lockfile had `0.34.5`
 - **Validation status:** `pnpm install --lockfile-only`
 
-## CVE-2026-41907 - uuid buffer bounds (11.x only)
+## CVE-2026-41907 - uuid buffer bounds
 
-- **Date:** `2026-08-14`
+- **Date:** `2026-08-27`
 - **Package:** `uuid` (npm, transitive)
-- **Vulnerable range (patched here):** `>=11.0.0 <11.1.1`
-- **Fixed/blocked target:** `11.1.1` via pnpm override `uuid@>=11.0.0 <11.1.1`
-- **Mitigation type:** override (fail-closed) for 11.x only
-- **MAJOR BUMP DEFERRED:** residual `uuid@8` / `9` have no same-major patch; forcing `11.1.1` is a major jump (wallet/connector chains). Residual Dependabot alert accepted until parents can upgrade.
+- **Vulnerable range:** `<11.1.1`
+- **Fixed/blocked target:** `11.1.1` via pnpm override `uuid@<11.1.1`
+- **Mitigation type:** override (fail-closed). **MAJOR BUMP APPLIED** for residual `uuid@8` / `9` (MetaMask SDK/utils) onto 11.1.1. uuid 12+ not used (drops CJS).
 - **Validation status:** `pnpm install --lockfile-only`
 
 ## Installation

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   ip-address@<10.3.1: 10.3.1
   nanoid@>=4.0.0 <5.1.16: 5.1.16
   nanoid@<3.3.18: 3.3.18
-  uuid@>=11.0.0 <11.1.1: 11.1.1
+  uuid@<11.1.1: 11.1.1
   sharp@<0.35.0: 0.35.3
   '@noble/curves': 1.9.5
   '@noble/hashes': 1.8.0
@@ -2450,6 +2450,7 @@ packages:
   eslint@9.32.0:
     resolution: {integrity: sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -3482,7 +3483,7 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': '*'
-      react: '>=19.1.2'
+      react: '>=19.0.1'
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -4019,14 +4020,8 @@ packages:
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -4683,7 +4678,7 @@ snapshots:
       readable-stream: 3.6.2
       socket.io-client: 4.8.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       utf-8-validate: 5.0.10
-      uuid: 8.3.2
+      uuid: 11.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4712,7 +4707,7 @@ snapshots:
       socket.io-client: 4.8.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       tslib: 2.8.1
       util: 0.12.5
-      uuid: 8.3.2
+      uuid: 11.1.1
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -4733,7 +4728,7 @@ snapshots:
       lodash: 4.18.1
       pony-cause: 2.1.11
       semver: 7.8.5
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4757,7 +4752,7 @@ snapshots:
       debug: 4.4.3
       pony-cause: 2.1.11
       semver: 7.8.5
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4771,7 +4766,7 @@ snapshots:
       debug: 4.4.3
       pony-cause: 2.1.11
       semver: 7.8.5
-      uuid: 9.0.1
+      uuid: 11.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -9325,9 +9320,7 @@ snapshots:
       is-typed-array: 1.1.15
       which-typed-array: 1.1.20
 
-  uuid@8.3.2: {}
-
-  uuid@9.0.1: {}
+  uuid@11.1.1: {}
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,8 +52,8 @@ overrides:
   "ip-address@<10.3.1": "10.3.1"
   "nanoid@>=4.0.0 <5.1.16": "5.1.16"
   "nanoid@<3.3.18": "3.3.18"
-  # CVE-2026-41907 / GHSA-w5hq-g745-h8pq: uuid buffer bounds (11.x only; 8/9/10 deferred)
-  "uuid@>=11.0.0 <11.1.1": "11.1.1"
+  # CVE-2026-41907 / GHSA-w5hq-g745-h8pq: uuid buffer bounds (8/9/10/11.0 → 11.1.1; MAJOR for prior 8/9/10)
+  "uuid@<11.1.1": "11.1.1"
   # GHSA-f88m-g3jw-g9cj: sharp libvips inherited CVEs (high)
   "sharp@<0.35.0": "0.35.3"
   # Force @noble/curves to a version that HAS npm provenance attestation, so


### PR DESCRIPTION
## What
Widen the root pnpm uuid override from `uuid@>=11.0.0 <11.1.1` to `uuid@<11.1.1` → `11.1.1`.

## Why
CVE-2026-41907 / Dependabot still flags residual uuid 8/9 (MetaMask SDK/utils) after the 11.x-only pin in #80.

**Chains:** @metamask/sdk, @metamask/sdk-communication-layer, @metamask/utils.

## Test plan
- [x] `pnpm install --lockfile-only`
- [x] Lockfile has no `uuid@8` / `9` / `10` package keys
- [ ] CI lint/build passes
- [ ] Smoke: wallet connect / RPC id generation if those surfaces exist on this repo

## Security & Data Impact
**Security impact:** Clears CVE-2026-41907 / GHSA-w5hq-g745-h8pq (buffer bounds on v3/v5/v6 when caller passes `buf`). Exploitability in these trees is low (`v4()` request IDs); this is to suppress Dependabot.
**Data classification affected:** none
**Audit log updated:** n/a

## Breaking Changes
⚠️ MAJOR: transitive `uuid` 8/9/10 → 11.1.1 via pnpm override. uuid 11 still ships CJS (12+ does not — not used). Rollback: revert the override key to `uuid@>=11.0.0 <11.1.1`.